### PR TITLE
Update new dev build workflow for easier automated access

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -14,6 +14,8 @@ jobs:
           distribution: adopt
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Duplicate file for wget/cron access to auto update
+        run: cp ./build/libs/*.jar qma-latest.jar
       - name: Release
         uses: marvinpinto/action-automatic-releases@latest
         with:

--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -14,8 +14,8 @@ jobs:
           distribution: adopt
       - name: Build with Gradle
         run: ./gradlew build
-      - name: Duplicate file for wget/cron access to auto update
-        run: cp ./build/libs/*.jar qma-latest.jar
+      - name: Duplicate artifact file for easy wget/cron access to auto update
+        run: cp ./build/libs/*.jar ./build/libs/qma-latest.jar
       - name: Release
         uses: marvinpinto/action-automatic-releases@latest
         with:


### PR DESCRIPTION
e.g. put something like `0 * * * * curl https://github.com/qwertyquarty/quartys-meteor-additions/releases/download/latest/qma-latest.jar > ~/.minecraft/mods/qma-latest.jar` in your crontab so it automatically updates every hour